### PR TITLE
Updated the docker image with new defaults.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ name: Build HDF5 Wasm
 jobs:
   build-wasm:
     runs-on: ubuntu-latest
-    container: ghcr.io/ltla/emcmake-docker/builder:2022-12-13
+    container: ghcr.io/ltla/emcmake-docker/builder:2023-07-17
     
     steps:
       - name: Checkout


### PR DESCRIPTION
Minor change to just use an updated version of the Docker image that has a newer default CMake and emsdk repository. This seems to work pretty well, see https://github.com/kanaverse/libhdf5-wasm/releases/tag/v0.3.0_3.1.43.