### PR TITLE
Build tools

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,13 +2,14 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 name: Build HDF5 Wasm
 
 jobs:
   build-wasm:
     runs-on: ubuntu-latest
-    container: ghcr.io/ltla/emcmake-docker/builder:2023-07-17
+    container: ghcr.io/kanaverse/emcmake-docker/builder:2024-10-01
     
     steps:
       - name: Checkout
@@ -50,7 +51,8 @@ jobs:
           cat release.txt
 
       - name: Publish tarballs
-        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
         with:
           files: "*-Emscripten.tar.gz"
           name: ${{ env.TITLE }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .DS_Store
 libhdf5-*-wasm.tar*
-wasm_build/**
+HDF5*.tar.gz
+build/**
+dist/**
+tools/*
+tools-package/bin/*
+tools-package/*.tgz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,87 +29,66 @@ set (patch_files_command)
 if(PATCH_FILES)
     foreach(patch_file ${PATCH_FILES})
         list(APPEND patch_files_command
-           COMMAND git apply --ignore-whitespace "${patch_file}"
+           COMMAND patch -p1 --forward --ignore-whitespace -i "${patch_file}"
         )
     endforeach()
 endif()
 
 FetchContent_Declare(
   hdf5
-  GIT_REPOSITORY https://github.com/HDFGroup/hdf5.git
-  GIT_TAG hdf5-${HDF5_VERSION}
+  URL https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-${HDF5_VERSION}.tar.gz
+  URL_HASH SHA256=${SRC_HASH_${HDF5_VERSION}}
   PATCH_COMMAND ${patch_files_command}
   UPDATE_DISCONNECTED 1
+  # prevent running CMakeLists.txt immediately, see
+  # https://discourse.cmake.org/t/prevent-fetchcontent-makeavailable-to-execute-cmakelists-txt/12704
+  # (makes FetchContent_MakeAvailable work like deprecated FetchContent_Populate)
+  SOURCE_SUBDIR non_existant_dir
 )
 FetchContent_GetProperties(hdf5)
 if (NOT hdf5_POPULATED)
-  FetchContent_Populate(hdf5)
+  FetchContent_MakeAvailable(hdf5)
 endif()
 
-FetchContent_Declare(
-  zlib
-  URL http://zlib.net/fossils/zlib-1.3.tar.gz
-  URL_HASH  SHA256=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
-  OVERRIDE_FIND_PACKAGE
-)
-FetchContent_Populate(zlib)
-
-# add global included path because zlib not set up to be subproject
-include_directories(${zlib_SOURCE_DIR} ${zlib_BINARY_DIR})
-add_subdirectory(${zlib_SOURCE_DIR} ${zlib_BINARY_DIR})
-# FetchContent_MakeAvailable(zlib)
-set(ZLIB_INCLUDE_DIR ${zlib_SOURCE_DIR})
-set(ZLIB_LIBRARY ${zlib_BINARY_DIR}/libz.a)
-
-FetchContent_Declare(
-  libaec
-  GIT_REPOSITORY https://gitlab.dkrz.de/k202009/libaec
-  GIT_TAG v1.0.6
-)
-set(libaec_USE_STATIC_LIBS ON)
-FetchContent_MakeAvailable(libaec)
-
-set (USE_LIBAEC ON CACHE BOOL "Use libaec szip replacement" FORCE)
-set (USE_LIBAEC_STATIC ON CACHE BOOL "Use libaec szip replacement" FORCE)
-set (SZIP_INCLUDE_DIR ${libaec_SOURCE_DIR}/include)
-set (SZIP_LIBRARY ${libaec_BINARY_DIR}/src/libsz.a)
-set (libaec_DIR ${libaec_BINARY_DIR}/cmake)
-set (libaec_ROOT ${libaec_BINARY_DIR})
-# find_package(libaec 1.0.5 REQUIRED CONFIG)
-set (libaec_INCLUDE_DIR ${libaec_SOURCE_DIR}/include)
-set (libaec_LIBRARY ${libaec_BINARY_DIR}/libaec.a)
+include(${hdf5_SOURCE_DIR}/config/cmake/cacheinit.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/wasm-settings.cmake)
+set(HDF5_PLUGIN_SYMBOLS_STRING "" CACHE STRING "Emscripten exported functions string - only populate if building executables")
+if(HDF5_BUILD_TOOLS)
+  # this brings in the HDF5_PLUGIN_SYMBOLS_STRING and HDF5_PLUGIN_SYMBOLS variables and
+  # the format_exported_functions() function
+  include(${CMAKE_CURRENT_SOURCE_DIR}/plugin_symbols.cmake)
+endif()
 
 # set the project name
 project(libhdf5-wasm-build)
 
-## This doesn't work because of naming of libszaec vs. libsz
-## The USE_LIBAEC=ON setting sets the wrong library name (libszaec),
-## while USE_LIBAEC=OFF sets the wrong include_dir (should be SOURCE/include instead of SOURCE/src)
-# set(HDF5_ALLOW_EXTERNAL_SUPPORT "GIT" CACHE STRING "" FORCE)
-# set(ZLIB_GIT_URL https://github.com/madler/zlib)
-# set(ZLIB_GIT_BRANCH v1.3)
-# set(SZIP_GIT_URL https://gitlab.dkrz.de/k202009/libaec)
-# set(SZIP_GIT_BRANCH v1.0.6)
-
-set (BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-option(BUILD_SHARED_LIBS "Build shared libs" OFF)
-option(HDF5_BUILD_EXAMPLES "Build Examples" OFF)
-option(HDF5_BUILD_TOOLS "Build Tools" OFF)
-option(HDF5_BUILD_UTILS "Build Utils" OFF)
-option(HDF5_BUILD_CPP_LIB "Build CPP libraries" ON)
-option(HDF5_ENABLE_Z_LIB_SUPPORT "Enable ZLIB" ON)
-option(HDF5_ENABLE_SZIP_SUPPORT "Enable SZIP" ON)
-option(SZIP_USE_EXTERNAL "needs to be off" 0)
-option(ZLIB_USE_EXTERNAL "needs to be off" 0)
-
-set (BUILD_TESTING OFF CACHE BOOL "Do not build tests by default" FORCE)
-set(HDF5_EXTERNALLY_CONFIGURED 1)
-set(H5_HAVE_GETPWUID OFF)
-set(H5_HAVE_SIGNAL OFF)
-
 set(CMAKE_BUILD_TYPE RELEASE)
 
 add_subdirectory(${hdf5_SOURCE_DIR} ${hdf5_BINARY_DIR})
+
+# Add plugin support linker flags to HDF5 tools after they're defined
+if(HDF5_BUILD_TOOLS)
+  # List of HDF5 tools to modify
+  set (HDF5_TOOLS h5dump h5repack h5diff h5ls h5stat h5copy h5mkgrp h5repart h5jam h5unjam h5clear h5debug h5format_convert h5perf_serial h5watch)
+  list (APPEND HDF5_PLUGIN_SYMBOLS main)
+  format_exported_functions(HDF5_PLUGIN_SYMBOLS HDF5_PLUGIN_SYMBOLS_STRING)
+
+  foreach(tool ${HDF5_TOOLS})
+    if(TARGET ${tool})
+      target_link_options(${tool} PRIVATE
+        -sALLOW_MEMORY_GROWTH=1
+        -sALLOW_TABLE_GROWTH=1
+        -sMAIN_MODULE=2
+        -sWASM_BIGINT=1
+        -sENVIRONMENT=node
+        --pre-js=${CMAKE_SOURCE_DIR}/env-setup.js
+        "SHELL:-sEXPORTED_FUNCTIONS=\"${HDF5_PLUGIN_SYMBOLS_STRING}\""
+      )
+    endif()
+  endforeach()
+  message(STATUS "Added Emscripten linker options to HDF5 tools")
+endif()
+
 install(EXPORT hdf5-targets DESTINATION cmake)
 install (
     FILES ${hdf5_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/hdf5-config.cmake

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,39 @@
-INSTALL_PREFIX = $(realpath .)/dist
+INSTALL_PREFIX = $(CURDIR)/dist
 BUILD_DIR = build
-HDF5_VERSIONS = 1_12_3 1.14.6 1_10_11
+TOOLS_DIR = tools
+TOOLS_PACKAGE_DIR = tools-package
+HDF5_VERSIONS = 1_10_11 1_12_3 1.14.6
+HDF5_DEFAULT_VERSION = $(lastword $(HDF5_VERSIONS))
 HDF5_TARBALLS = $(patsubst %, HDF5-%-Emscripten.tar.gz, $(HDF5_VERSIONS))
+HDF5_DEFAULT_TARBALL = HDF5-$(HDF5_DEFAULT_VERSION)-Emscripten.tar.gz
+
+.PHONY: all default tools shasum clean help
 
 all: $(HDF5_TARBALLS)
+default: $(HDF5_DEFAULT_TARBALL)
 
 HDF5-%-Emscripten.tar.gz:
 	emcmake cmake -DCMAKE_INSTALL_PREFIX="$(INSTALL_PREFIX)/$(*)" -DHDF5_VERSION=$(*) -S . -B $(BUILD_DIR)/$(*);
-	cmake --build $(BUILD_DIR)/$(*) --target zlibstatic;
-	cmake --build $(BUILD_DIR)/$(*) --target sz_static;
 	cmake --build $(BUILD_DIR)/$(*) -j8;
 	cmake --install $(BUILD_DIR)/$(*);
-	sed -i -- 's/;[^;]*ZLIB::ZLIB>/;$${_IMPORT_PREFIX}\/lib\/libz.a/g' $(INSTALL_PREFIX)/$(*)/cmake/hdf5-targets.cmake;
-	sed -i -- 's/;[^;]*libaec::sz>/;$${_IMPORT_PREFIX}\/lib\/libsz.a/g' $(INSTALL_PREFIX)/$(*)/cmake/hdf5-targets.cmake;
-	sed -i -- 's/;[^;]*libaec::aec>//g' $(INSTALL_PREFIX)/$(*)/cmake/hdf5-targets.cmake;
-	sed -i -- 's/;[^;]*libz\.a/;$${_IMPORT_PREFIX}\/lib\/libz.a/g' $(INSTALL_PREFIX)/$(*)/cmake/hdf5-targets.cmake;
-	sed -i -- 's/;[^;]*libsz\.a/;$${_IMPORT_PREFIX}\/lib\/libsz.a/g' $(INSTALL_PREFIX)/$(*)/cmake/hdf5-targets.cmake;
-	cp CMakeLists_dist.txt $(INSTALL_PREFIX)/CMakeLists.txt;
 	cd $(INSTALL_PREFIX)/$(*) && tar -cvzf ../../$@ *;
 
+$(TOOLS_DIR)/.ready:
+	@echo "Extracting tools from default version..."
+	@mkdir -p $(TOOLS_DIR);
+	emcmake cmake -DCMAKE_INSTALL_PREFIX="$(INSTALL_PREFIX)/tools" \
+		-DHDF5_VERSION=$(HDF5_DEFAULT_VERSION) \
+		-S . -B $(BUILD_DIR)/tools \
+		-DHDF5_BUILD_TOOLS=ON;
+	cmake --build $(BUILD_DIR)/tools -j8;
+	cmake --install $(BUILD_DIR)/tools;
+	@cp $(INSTALL_PREFIX)/tools/bin/* $(TOOLS_DIR)/;
+	@mkdir -p $(TOOLS_PACKAGE_DIR)/bin/;
+	@cp $(INSTALL_PREFIX)/tools/bin/* $(TOOLS_PACKAGE_DIR)/bin/;
+	@touch $@
+
+tools: $(TOOLS_DIR)/.ready
+	@echo "Tools extracted to $(TOOLS_DIR)/"
 
 shasum: $(HDF5_TARBALLS)
 	@for t in $(HDF5_TARBALLS); do shasum -a 256 $$t; done;
@@ -28,3 +43,5 @@ clean:
 	rm -f *-Emscripten.tar.gz;
 	rm -rf dist;
 	rm -rf build;
+	rm -rf $(TOOLS_DIR);
+	rm -rf $(TOOLS_PACKAGE_DIR)/bin/*;

--- a/env-setup.js
+++ b/env-setup.js
@@ -1,0 +1,21 @@
+// Set up environment variables from process.env for Emscripten
+var Module = typeof Module !== 'undefined' ? Module : {};
+
+// Hook into Module initialization to set up environment
+Module['preRun'] = Module['preRun'] || [];
+Module['preRun'].push(function() {
+  if (typeof process !== 'undefined') {
+    // Use HDF5_PLUGIN_PATH from environment if set
+    if (process.env && process.env.HDF5_PLUGIN_PATH) {
+      ENV['HDF5_PLUGIN_PATH'] = process.env.HDF5_PLUGIN_PATH;
+    }
+    // Otherwise, set a default path relative to the script location
+    else if (typeof __dirname !== 'undefined') {
+      // When installed: __dirname is node_modules/hdf5-wasm-tools/bin
+      // We want to look for plugins at: node_modules/h5wasm-plugins/plugins
+      var path = require('path');
+      var defaultPluginPath = path.join(__dirname, '..', '..', 'h5wasm-plugins', 'plugins');
+      ENV['HDF5_PLUGIN_PATH'] = defaultPluginPath;
+    }
+  }
+});

--- a/env-setup.js
+++ b/env-setup.js
@@ -5,17 +5,29 @@ var Module = typeof Module !== 'undefined' ? Module : {};
 Module['preRun'] = Module['preRun'] || [];
 Module['preRun'].push(function() {
   if (typeof process !== 'undefined') {
-    // Use HDF5_PLUGIN_PATH from environment if set
-    if (process.env && process.env.HDF5_PLUGIN_PATH) {
-      ENV['HDF5_PLUGIN_PATH'] = process.env.HDF5_PLUGIN_PATH;
-    }
-    // Otherwise, set a default path relative to the script location
-    else if (typeof __dirname !== 'undefined') {
+    // Determine the default plugin path relative to the script location
+    var defaultPluginPath = null;
+    if (typeof __dirname !== 'undefined') {
       // When installed: __dirname is node_modules/hdf5-wasm-tools/bin
       // We want to look for plugins at: node_modules/h5wasm-plugins/plugins
       var path = require('path');
-      var defaultPluginPath = path.join(__dirname, '..', '..', 'h5wasm-plugins', 'plugins');
-      ENV['HDF5_PLUGIN_PATH'] = defaultPluginPath;
+      defaultPluginPath = path.join(__dirname, '..', '..', 'h5wasm-plugins', 'plugins');
+    }
+
+    // Get the plugin path from environment or use default
+    var pluginPath = (process.env && process.env.HDF5_PLUGIN_PATH) || defaultPluginPath;
+
+    if (pluginPath) {
+      // Set in ENV object (for Node.js/Emscripten)
+      if (typeof ENV !== 'undefined') {
+        ENV['HDF5_PLUGIN_PATH'] = pluginPath;
+      }
+
+      // Also set in process.env for Bun and other runtimes
+      if (process.env) {
+        process.env.HDF5_PLUGIN_PATH = pluginPath;
+      }
     }
   }
 });
+

--- a/plugin_symbols.cmake
+++ b/plugin_symbols.cmake
@@ -1,0 +1,51 @@
+# Function to convert a list of symbol names to Emscripten EXPORTED_FUNCTIONS format
+# Usage: format_exported_functions(<input_list> <output_variable>)
+# Example: format_exported_functions(MY_SYMBOLS MY_SYMBOLS_STRING)
+function(format_exported_functions input_list output_var)
+    # Make a copy of the input list to work with
+    set(symbols ${${input_list}})
+    
+    # Add '_' prefix and wrap each symbol in single quotes
+    list(TRANSFORM symbols PREPEND "'_")
+    list(TRANSFORM symbols APPEND "'")
+    
+    # Join with comma and space, then wrap in brackets
+    list(JOIN symbols ", " symbols_string)
+    set(symbols_string "[${symbols_string}]")
+    
+    # Set the output variable in parent scope
+    set(${output_var} "${symbols_string}" PARENT_SCOPE)
+endfunction()
+
+set (HDF5_PLUGIN_SYMBOLS)
+list (APPEND HDF5_PLUGIN_SYMBOLS
+    H5Fopen H5Fclose H5Fcreate H5open
+    malloc calloc free memset memcpy memmove realloc
+    htonl htons ntohl ntohs
+    H5allocate_memory H5free_memory
+    pthread_mutex_init posix_memalign strcmp strcpy sscanf getenv
+    stdin stdout stderr clock_gettime
+    strlen strdup snprintf iprintf
+    pthread_create pthread_mutex_lock pthread_mutex_unlock pthread_atfork pthread_once
+    pthread_cond_init pthread_barrier_init pthread_attr_init pthread_attr_setdetachstate
+    H5Pget_chunk H5Tget_class H5Sget_simple_extent_dims
+    H5Pget_filter_by_id2 H5Pmodify_filter H5Pexist
+    H5Tget_size H5Tget_native_type H5Tget_order
+    H5Epush2 siprintf getTempRet0 __wasm_setjmp
+    H5E_ERR_CLS_g H5E_PLINE_g H5E_CANTINIT_g H5E_CANTGET_g H5E_CANTFILTER_g
+    H5E_BADTYPE_g H5E_BADVALUE_g H5E_ARGS_g H5E_CALLBACK_g H5E_CANTREGISTER_g
+    H5E_RESOURCE_g H5E_NOSPACE_g H5E_OVERFLOW_g H5E_READERROR_g
+    H5Sis_simple H5Pfill_value_defined
+    H5T_NATIVE_UINT_g H5T_STD_U32BE_g H5T_STD_U32LE_g H5T_NATIVE_UINT32_g
+    H5T_STD_U64BE_g H5T_NATIVE_UINT64_g H5T_STD_U64LE_g H5P_CLS_DATASET_CREATE_ID_g
+    frexp frexpf log10 ldexpf __THREW__ __threwValue
+)
+
+# Convert the symbol list to Emscripten format
+format_exported_functions(HDF5_PLUGIN_SYMBOLS HDF5_PLUGIN_SYMBOLS_STRING)
+
+# Results in variable HDF5_PLUGIN_SYMBOLS_STRING containing the symbols to export
+# Use as: -s EXPORTED_FUNCTIONS="${HDF5_PLUGIN_SYMBOLS_STRING}"
+# Or, to test adding new symbols:
+# list(APPEND HDF5_PLUGIN_SYMBOLS foo bar baz)
+# format_exported_functions(HDF5_PLUGIN_SYMBOLS HDF5_PLUGIN_SYMBOLS_STRING)

--- a/tools-package/LICENSE.txt
+++ b/tools-package/LICENSE.txt
@@ -1,0 +1,133 @@
+libhdf5-wasm license statement:
+
+NIST-developed software is provided by NIST as a public service. You may use, 
+copy, and distribute copies of the software in any medium, provided that you 
+keep intact this entire notice. You may improve, modify, and create derivative 
+works of the software or any portion of the software, and you may copy and 
+distribute such modifications or works. Modified works should carry a notice 
+stating that you changed the software and should note the date and nature of 
+any such change. Please explicitly acknowledge the National Institute of 
+Standards and Technology as the source of the software. 
+
+NIST-developed software is expressly provided "AS IS." NIST MAKES NO WARRANTY 
+OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY OPERATION OF LAW, 
+INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTY OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND DATA ACCURACY. NIST 
+NEITHER REPRESENTS NOR WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE 
+UNINTERRUPTED OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES 
+NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE SOFTWARE OR 
+THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE CORRECTNESS, ACCURACY, 
+RELIABILITY, OR USEFULNESS OF THE SOFTWARE.
+
+You are solely responsible for determining the appropriateness of using and 
+distributing the software and you assume all risks associated with its use, 
+including but not limited to the risks and costs of program errors, compliance 
+with applicable laws, damage to or loss of data, programs or equipment, 
+and the unavailability or interruption of operation. This software is not 
+intended to be used in any situation where a failure could cause risk of 
+injury or damage to property. The software developed by NIST employees is not 
+subject to copyright protection within the United States.
+
+******************************************************************************
+
+Built using the HDF5 library.  HDF5 Copyright statement is included below:
+
+Copyright Notice and License Terms for 
+HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+-----------------------------------------------------------------------------
+
+HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+Copyright 2006 by The HDF Group. 
+
+NCSA HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+Copyright 1998-2006 by The Board of Trustees of the University of Illinois. 
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted for any purpose (including commercial purposes) 
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, 
+   this list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, 
+   this list of conditions, and the following disclaimer in the documentation 
+   and/or materials provided with the distribution.
+
+3. Neither the name of The HDF Group, the name of the University, nor the 
+   name of any Contributor may be used to endorse or promote products derived 
+   from this software without specific prior written permission from 
+   The HDF Group, the University, or the Contributor, respectively.
+
+DISCLAIMER: 
+THIS SOFTWARE IS PROVIDED BY THE HDF GROUP AND THE CONTRIBUTORS 
+"AS IS" WITH NO WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED. IN NO 
+EVENT SHALL THE HDF GROUP OR THE CONTRIBUTORS BE LIABLE FOR ANY DAMAGES 
+SUFFERED BY THE USERS ARISING OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+You are under no obligation whatsoever to provide any bug fixes, patches, or 
+upgrades to the features, functionality or performance of the source code 
+("Enhancements") to anyone; however, if you choose to make your Enhancements 
+available either publicly, or directly to The HDF Group, without imposing a 
+separate written license agreement for such Enhancements, then you hereby 
+grant the following license: a non-exclusive, royalty-free perpetual license 
+to install, use, modify, prepare derivative works, incorporate into other 
+computer software, distribute, and sublicense such enhancements or derivative 
+works thereof, in binary and source code form.
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Limited portions of HDF5 were developed by Lawrence Berkeley National 
+Laboratory (LBNL). LBNL's Copyright Notice and Licensing Terms can be
+found here: COPYING_LBNL_HDF5 file in this directory or at 
+http://support.hdfgroup.org/ftp/HDF5/releases/COPYING_LBNL_HDF5. 
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Contributors:   National Center for Supercomputing Applications (NCSA) at 
+the University of Illinois, Fortner Software, Unidata Program Center 
+(netCDF), The Independent JPEG Group (JPEG), Jean-loup Gailly and Mark Adler 
+(gzip), and Digital Equipment Corporation (DEC).
+
+-----------------------------------------------------------------------------
+ 
+Portions of HDF5 were developed with support from the Lawrence Berkeley 
+National Laboratory (LBNL) and the United States Department of Energy 
+under Prime Contract No. DE-AC02-05CH11231.
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from the University of 
+California, Lawrence Livermore National Laboratory (UC LLNL).  
+The following statement applies to those portions of the product and must 
+be retained in any redistribution of source code, binaries, documentation, 
+and/or accompanying materials:
+
+   This work was partially produced at the University of California, 
+   Lawrence Livermore National Laboratory (UC LLNL) under contract 
+   no. W-7405-ENG-48 (Contract 48) between the U.S. Department of Energy 
+   (DOE) and The Regents of the University of California (University) 
+   for the operation of UC LLNL.
+
+   DISCLAIMER: 
+   THIS WORK WAS PREPARED AS AN ACCOUNT OF WORK SPONSORED BY AN AGENCY OF 
+   THE UNITED STATES GOVERNMENT. NEITHER THE UNITED STATES GOVERNMENT NOR 
+   THE UNIVERSITY OF CALIFORNIA NOR ANY OF THEIR EMPLOYEES, MAKES ANY 
+   WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LIABILITY OR RESPONSIBILITY 
+   FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS OF ANY INFORMATION, 
+   APPARATUS, PRODUCT, OR PROCESS DISCLOSED, OR REPRESENTS THAT ITS USE 
+   WOULD NOT INFRINGE PRIVATELY- OWNED RIGHTS. REFERENCE HEREIN TO ANY 
+   SPECIFIC COMMERCIAL PRODUCTS, PROCESS, OR SERVICE BY TRADE NAME, 
+   TRADEMARK, MANUFACTURER, OR OTHERWISE, DOES NOT NECESSARILY CONSTITUTE 
+   OR IMPLY ITS ENDORSEMENT, RECOMMENDATION, OR FAVORING BY THE UNITED 
+   STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA. THE VIEWS AND 
+   OPINIONS OF AUTHORS EXPRESSED HEREIN DO NOT NECESSARILY STATE OR REFLECT 
+   THOSE OF THE UNITED STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA, 
+   AND SHALL NOT BE USED FOR ADVERTISING OR PRODUCT ENDORSEMENT PURPOSES.
+
+-----------------------------------------------------------------------------
+

--- a/tools-package/package.json
+++ b/tools-package/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "hdf5-wasm-tools",
+  "version": "0.1.0",
+  "description": "Tools from the HDF5 library compiled to WebAssembly",
+  "homepage": "https://github.com/usnistgov/libhdf5-wasm/tree/main/tools-package",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usnistgov/libhdf5-wasm.git"
+  },
+  "bin": {
+    "h5clear": "./bin/h5clear",
+    "h5copy": "./bin/h5copy",
+    "h5debug": "./bin/h5debug",
+    "h5delete": "./bin/h5delete",
+    "h5diff": "./bin/h5diff",
+    "h5dump": "./bin/h5dump",
+    "h5format_convert": "./bin/h5format_convert",
+    "h5import": "./bin/h5import",
+    "h5jam": "./bin/h5jam",
+    "h5ls": "./bin/h5ls",
+    "h5mkgrp": "./bin/h5mkgrp",
+    "h5perf_serial": "./bin/h5perf_serial",
+    "h5repack": "./bin/h5repack",
+    "h5repart": "./bin/h5repart",
+    "h5stat": "./bin/h5stat",
+    "h5unjam": "./bin/h5unjam",
+    "h5watch": "./bin/h5watch"
+  },
+  "files": [
+    "bin/",
+    "LICENSE.txt"
+  ],
+  "author": "",
+  "license": "SEE LICENSE IN LICENSE.txt"
+}

--- a/wasm-settings.cmake
+++ b/wasm-settings.cmake
@@ -1,0 +1,80 @@
+# CMake cache initialization file for HDF5 WebAssembly builds
+# Usage: emcmake cmake -C wasm-settings.cmake -S /path/to/hdf5 -B build-wasm
+
+# Build type
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
+
+# Install directories - use simple relative paths to avoid nested structure
+set(HDF5_INSTALL_BIN_DIR "bin" CACHE STRING "Binary install directory" FORCE)
+set(HDF5_INSTALL_LIB_DIR "lib" CACHE STRING "Library install directory" FORCE)
+set(HDF5_INSTALL_INCLUDE_DIR "include" CACHE STRING "Include install directory" FORCE)
+set(HDF5_INSTALL_CMAKE_DIR "cmake" CACHE STRING "CMake install directory" FORCE)
+set(HDF5_INSTALL_DATA_DIR "share" CACHE STRING "Data install directory" FORCE)
+
+# External library support - use HDF5's built-in download mechanism
+set(HDF5_ALLOW_EXTERNAL_SUPPORT "TGZ" CACHE STRING "Allow External Library Building (NO GIT TGZ)" FORCE)
+
+# Download from URLs, not local files
+set(ZLIB_USE_LOCALCONTENT OFF CACHE BOOL "Use local file for ZLIB FetchContent" FORCE)
+set(LIBAEC_USE_LOCALCONTENT OFF CACHE BOOL "Use local file for LIBAEC FetchContent" FORCE)
+
+# Force use of FetchContent to download from URLs (for 1_10_11 compatibility)
+set(BUILD_ZLIB_WITH_FETCHCONTENT ON CACHE BOOL "Build ZLIB with FetchContent" FORCE)
+set(BUILD_SZIP_WITH_FETCHCONTENT ON CACHE BOOL "Build SZIP with FetchContent" FORCE)
+
+# Use consistent zlib and libaec versions for all HDF5 versions
+# Override the version-specific cacheinit.cmake settings
+# Note: Different HDF5 versions use different variable names (TGZ_ORIGNAME vs TGZ_NAME)
+# set(ZLIB_TGZ_ORIGPATH "https://github.com/madler/zlib/releases/download/v1.3.1" CACHE STRING "Use ZLIB from original location" FORCE)
+# set(ZLIB_TGZ_ORIGNAME "zlib-1.3.1.tar.gz" CACHE STRING "Use ZLIB from original compressed file (1_10_11)" FORCE)
+# set(ZLIB_TGZ_NAME "zlib-1.3.1.tar.gz" CACHE STRING "Use HDF5_ZLib from compressed file" FORCE)
+# set(LIBAEC_TGZ_ORIGPATH "https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.3" CACHE STRING "Use LIBAEC from original location" FORCE)
+# set(LIBAEC_TGZ_ORIGNAME "libaec-1.1.3.tar.gz" CACHE STRING "Use LIBAEC from original compressed file (1_10_11)" FORCE)
+# set(SZAEC_TGZ_ORIGPATH "https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.3" CACHE STRING "Use SZAEC from original location" FORCE)
+# set(SZAEC_TGZ_NAME "libaec-1.1.3.tar.gz" CACHE STRING "Use SZip AEC from compressed file" FORCE)
+# set(LIBAEC_TGZ_NAME "libaec-1.1.3.tar.gz" CACHE STRING "Use LIBAEC from compressed file" FORCE)
+
+# External libraries to use
+set(ZLIB_USE_EXTERNAL ON CACHE BOOL "Use external ZLIB library" FORCE)
+set(SZIP_USE_EXTERNAL ON CACHE BOOL "Use external SZIP library" FORCE)
+
+# Static linking
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
+set(BUILD_STATIC_LIBS ON CACHE BOOL "Build static libraries" FORCE)
+set(HDF5_USE_ZLIB_STATIC ON CACHE BOOL "Use static zlib library" FORCE)
+set(HDF5_USE_LIBAEC_STATIC ON CACHE BOOL "Use static libaec library" FORCE)
+
+# Language support
+set(HDF5_BUILD_FORTRAN OFF CACHE BOOL "Build Fortran libraries" FORCE)
+set(HDF5_BUILD_JAVA OFF CACHE BOOL "Build Java libraries" FORCE)
+
+# Feature builds
+set(HDF5_BUILD_TOOLS OFF CACHE BOOL "Build HDF5 Tools")
+set(HDF5_BUILD_CPP_LIB ON CACHE BOOL "Build C++ support" FORCE)
+set(HDF5_BUILD_EXAMPLES OFF CACHE BOOL "Build HDF5 Library Examples" FORCE)
+set(HDF5_BUILD_UTILS OFF CACHE BOOL "Build HDF5 Utils" FORCE)
+
+# Enable compression support
+set(HDF5_ENABLE_Z_LIB_SUPPORT ON CACHE BOOL "Enable ZLIB support" FORCE)
+set(HDF5_ENABLE_SZIP_SUPPORT ON CACHE BOOL "Enable SZIP support" FORCE)
+set(HDF5_ENABLE_SZIP_ENCODING ON CACHE BOOL "Enable SZIP encoding" FORCE)
+
+# Testing
+set(BUILD_TESTING OFF CACHE BOOL "Build HDF5 Unit Testing" FORCE)
+set(HDF5_BUILD_TESTS OFF CACHE BOOL "Build HDF5 Unit Testing" FORCE)
+
+# Packaging
+set(HDF5_PACKAGE_EXTLIBS ON CACHE BOOL "Package external libraries with HDF5" FORCE)
+
+# Disable unsupported features for WebAssembly
+set(H5_HAVE_GETPWUID OFF CACHE BOOL "Disable getpwuid (not available in Emscripten)" FORCE)
+set(H5_HAVE_SIGNAL OFF CACHE BOOL "Disable signal handling (not fully supported in Emscripten)" FORCE)
+
+# Optional: Position independent code (useful for some build scenarios)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "Build position independent code" FORCE)
+
+# Optional: Disable executable suffix for cleaner output names
+set(CMAKE_EXECUTABLE_SUFFIX_C "" CACHE STRING "Executable suffix" FORCE)
+
+# Indicate that HDF5 is using internal configuration
+set(HDF5_EXTERNALLY_CONFIGURED OFF CACHE BOOL "HDF5 externally configured" FORCE)


### PR DESCRIPTION
This PR adds a step for building the tools included in the HDF5 library, such as `h5dump` ,`h5repack`, etc. and reorganizes the build process to use the external sources for `libz` and `libaec` (szip) that are referred to in the `config/cmake/cacheinit.cmake` of the library, instead of manually specifying them.

The tools are copied to a javascript package subdirectory with a `package.json` etc.